### PR TITLE
Add Docker Compose setup for Python environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.11-slim
+WORKDIR /usr/src/app
+CMD ["python3"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # test
-test
+
+This repository contains a basic Python environment set up using Docker Compose.
+
+## Usage
+
+1. Build the Docker image:
+   ```bash
+   docker compose build
+   ```
+2. Start an interactive Python shell:
+   ```bash
+   docker compose run --rm python
+   ```
+
+The current directory will be mounted inside the container at `/usr/src/app` so any changes to files are reflected between the host and container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  python:
+    build: .
+    volumes:
+      - .:/usr/src/app
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## Summary
- add `Dockerfile` with Python 3.11
- create `docker-compose.yml` to start an interactive container
- update README with usage instructions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877afe38e5c832eaa6c65575cace914