### PR TITLE
Add directory structure for Docker and app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # test
-test
+
+This repository contains a basic Python environment set up using Docker Compose.
+
+The Docker configuration is located in the `docker/` directory, while all
+application code lives under `app/`.
+
+## Usage
+
+1. Build the Docker image:
+   ```bash
+   docker compose -f docker/docker-compose.yml build
+   ```
+2. Start an interactive Python shell:
+   ```bash
+   docker compose -f docker/docker-compose.yml run --rm python
+   ```
+
+The `app/` directory will be mounted inside the container at `/usr/src/app` so
+any changes to files are reflected between the host and container.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,1 @@
+print("Hello from app")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.11-slim
+WORKDIR /usr/src/app
+CMD ["python3"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+services:
+  python:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ../app:/usr/src/app
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## Summary
- move Docker and Compose files into `docker/`
- create `app/` directory with a sample `main.py`
- update README with new build and run instructions

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6877afe38e5c832eaa6c65575cace914