### PR TITLE
Add web server with Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # test
-test
+
+This repository contains a basic Python environment set up using Docker Compose.
+
+The Docker configuration is located in the `docker/` directory, while all
+application code lives under `app/`.
+
+## Usage
+
+1. Build the Docker image:
+   ```bash
+   docker compose -f docker/docker-compose.yml build
+   ```
+2. Start the web server:
+   ```bash
+   docker compose -f docker/docker-compose.yml up
+   ```
+
+The Flask server will be available at [http://localhost:8000](http://localhost:8000).
+The `app/` directory is mounted inside the container at `/usr/src/app` so any
+changes to files are reflected between the host and container.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,12 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.get("/")
+def index():
+    return "Hello from Flask"
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /usr/src/app
+RUN pip install flask
+CMD ["python", "main.py"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  python:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ../app:/usr/src/app
+    ports:
+      - "8000:8000"
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## Summary
- set up simple Flask server in `app/main.py`
- install Flask in Docker image and run app
- expose port 8000 via Compose
- update README with new instructions

## Testing
- `python3 -m py_compile app/main.py`
- `pip install flask` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877afe38e5c832eaa6c65575cace914